### PR TITLE
Generalize Matrix class to non-nested things

### DIFF
--- a/Haskell/scrabble.cabal
+++ b/Haskell/scrabble.cabal
@@ -40,6 +40,7 @@ library
    ,primitive      >= 0.6
    ,random-shuffle >= 0.0.4
    ,semigroups     >= 0.8.3.1       && < 1
+   ,transformers   >= 0.4
    ,trifecta       >= 1.5.1
    ,unordered-containers >= 0.2.5.0
    ,utf8-string    >= 0.3.6         && < 0.4

--- a/Haskell/src/Scrabble/Board.hs
+++ b/Haskell/src/Scrabble/Board.hs
@@ -32,17 +32,6 @@ class Vec m where
   before :: Int -> m a -> m a
   after  :: Int -> m a -> m a
 
-class Matrix m where
-  elemAt  :: Pos p => (m (m a)) -> p -> Maybe a
-  row     :: m (m a) -> Int -> Maybe (m a)
-  col     :: m (m a) -> Int -> Maybe (m a)
-  rows    :: m (m a) -> m (m a)
-  cols    :: m (m a) -> m (m a)
-  above   :: Pos p => m (m a) -> p -> m a
-  below   :: Pos p => m (m a) -> p -> m a
-  leftOf  :: Pos p => m (m a) -> p -> m a
-  rightOf :: Pos p => m (m a) -> p -> m a
-
 class Matrix b => Board b where
   putTile      :: Pos p => b (b Square) -> p -> Tile -> b (b Square)
   putWord      :: b (b Square) -> PutWord -> (b (b Square), Score)
@@ -56,20 +45,6 @@ getWordsAt b p = (getWordAt b p Horizontal, getWordAt b p Vertical)
 instance Vec [] where
   before = take
   after  = drop . (+1)
-
-instance Matrix [] where
-  elemAt  m p | x >= 0 && y >= 0 = Just (m !! y !! x) where (x,y) = coors p
-  elemAt  _ _ = Nothing
-  row     m y | y >= 0 = Just $ m !! y
-  row     _ _ = Nothing
-  col     m x | x >= 0 = Just $ fmap (!!x) m
-  col     _ _ = Nothing
-  rows    m   = m
-  cols    m   = Maybe.catMaybes $ fmap (col m) [0..14]
-  above   m p = Maybe.fromMaybe [] $ before (y p) <$> col m (x p)
-  below   m p = Maybe.fromMaybe [] $ after  (y p) <$> col m (x p)
-  leftOf  m p = Maybe.fromMaybe [] $ before (x p) <$> row m (y p)
-  rightOf m p = Maybe.fromMaybe [] $ after  (x p) <$> row m (y p)
 
 instance Board [] where
   putTile b p t              = putTileOnListBoard b p t

--- a/Haskell/src/Scrabble/Board.hs
+++ b/Haskell/src/Scrabble/Board.hs
@@ -5,7 +5,7 @@ module Scrabble.Board where
 
 import Data.Char (toUpper)
 import Data.Either (isRight)
-import Data.List (intercalate)
+import Data.List (foldl', intercalate)
 import Data.Maybe (Maybe)
 import qualified Data.Maybe as Maybe
 import Data.Set (Set)

--- a/Haskell/src/Scrabble/Board.hs
+++ b/Haskell/src/Scrabble/Board.hs
@@ -28,10 +28,6 @@ instance Show Square where
 
 type ListBoard  = [[Square]]
 
-class Vec m where
-  before :: Int -> m a -> m a
-  after  :: Int -> m a -> m a
-
 class Matrix b => Board b where
   putTile      :: Pos p => b (b Square) -> p -> Tile -> b (b Square)
   putWord      :: b (b Square) -> PutWord -> (b (b Square), Score)
@@ -41,10 +37,6 @@ class Matrix b => Board b where
 
 getWordsAt :: (Pos p, Board b) => b (b Square) -> p -> (Maybe [Square], Maybe [Square])
 getWordsAt b p = (getWordAt b p Horizontal, getWordAt b p Vertical)
-
-instance Vec [] where
-  before = take
-  after  = drop . (+1)
 
 instance Board [] where
   putTile b p t              = putTileOnListBoard b p t

--- a/Haskell/src/Scrabble/Commands/Interpreter.hs
+++ b/Haskell/src/Scrabble/Commands/Interpreter.hs
@@ -1,7 +1,7 @@
 module Scrabble.Commands.Interpreter where
 
 import Data.Char (toUpper)
-import Data.List (delete,groupBy,intersperse)
+import Data.List (delete,foldl',groupBy,intersperse)
 import Data.Maybe (catMaybes)
 import Scrabble.Bag
 import Scrabble.Board

--- a/Haskell/src/Scrabble/Matrix.hs
+++ b/Haskell/src/Scrabble/Matrix.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 module Scrabble.Matrix
   ( Matrix(..)
@@ -20,17 +19,18 @@ class Vec m where
   after  :: Int -> m a -> m a
 
 -- | A generic matrix type 'm', whose rows are represented by the
--- generic 'r'.
-class Matrix r m | m -> r where
+-- associated 'Row'.
+class Matrix m where
+  type Row m :: * -> *
   elemAt  :: Pos p => (m a) -> p -> Maybe a
-  row     :: m a -> Int -> Maybe (r a)
-  col     :: m a -> Int -> Maybe (r a)
+  row     :: m a -> Int -> Maybe (Row m a)
+  col     :: m a -> Int -> Maybe (Row m a)
   rows    :: m a -> m a
   cols    :: m a -> m a
-  above   :: Pos p => m a -> p -> r a
-  below   :: Pos p => m a -> p -> r a
-  leftOf  :: Pos p => m a -> p -> r a
-  rightOf :: Pos p => m a -> p -> r a
+  above   :: Pos p => m a -> p -> Row m a
+  below   :: Pos p => m a -> p -> Row m a
+  leftOf  :: Pos p => m a -> p -> Row m a
+  rightOf :: Pos p => m a -> p -> Row m a
 
 -- | '[[a]]' is an 'a' "matrix".
 type ListMatrix = Compose [] []
@@ -43,7 +43,8 @@ instance Vec [] where
   before = take
   after  = drop . (+1)
 
-instance Matrix [] ListMatrix where
+instance Matrix ListMatrix where
+  type Row ListMatrix = []
   elemAt  (LM m) p | x >= 0 && y >= 0 = Just (m !! y !! x) where (x,y) = coors p
   elemAt  _ _ = Nothing
   row     (LM m) y | y >= 0 = Just $ m !! y

--- a/Haskell/src/Scrabble/Matrix.hs
+++ b/Haskell/src/Scrabble/Matrix.hs
@@ -6,7 +6,7 @@
 module Scrabble.Matrix
   ( Matrix(..)
   , ListMatrix
-  , LM
+  , pattern LM
   , Vec(..)
   ) where
 
@@ -51,9 +51,8 @@ instance Matrix [] ListMatrix where
   col     (LM m) x | x >= 0 = Just $ fmap (!!x) m
   col     _ _ = Nothing
   rows    m   = m
-  cols    m   = Maybe.catMaybes $ fmap (col m) [0..14]
+  cols    m   = LM (Maybe.catMaybes $ fmap (col m) [0..14])
   above   m p = Maybe.fromMaybe [] $ before (y p) <$> col m (x p)
   below   m p = Maybe.fromMaybe [] $ after  (y p) <$> col m (x p)
   leftOf  m p = Maybe.fromMaybe [] $ before (x p) <$> row m (y p)
   rightOf m p = Maybe.fromMaybe [] $ after  (x p) <$> row m (y p)
-

--- a/Haskell/src/Scrabble/Matrix.hs
+++ b/Haskell/src/Scrabble/Matrix.hs
@@ -1,14 +1,26 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 module Scrabble.Matrix
   ( Matrix(..)
   , ListMatrix
   , LM
+  , Vec(..)
   ) where
 
-import Data.Functor.Compose
+import Data.Functor.Compose (Compose(..))
+import Data.Maybe (Maybe)
+import qualified Data.Maybe as Maybe
+import Scrabble.Types (Pos(..))
 
+class Vec m where
+  before :: Int -> m a -> m a
+  after  :: Int -> m a -> m a
+
+-- | A generic matrix type 'm', whose rows are represented by the
+-- generic 'r'.
 class Matrix r m | m -> r where
   elemAt  :: Pos p => (m a) -> p -> Maybe a
   row     :: m a -> Int -> Maybe (r a)
@@ -20,12 +32,16 @@ class Matrix r m | m -> r where
   leftOf  :: Pos p => m a -> p -> r a
   rightOf :: Pos p => m a -> p -> r a
 
--- | The composition of two lists forms a "matrix".
+-- | '[[a]]' is an 'a' "matrix".
 type ListMatrix = Compose [] []
 
 -- | A shorthand for getting the list-of-list out of a 'ListMatrix',
 -- and putting one back in.
 pattern LM a = Compose a
+
+instance Vec [] where
+  before = take
+  after  = drop . (+1)
 
 instance Matrix [] ListMatrix where
   elemAt  (LM m) p | x >= 0 && y >= 0 = Just (m !! y !! x) where (x,y) = coors p

--- a/Haskell/src/Scrabble/Matrix.hs
+++ b/Haskell/src/Scrabble/Matrix.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Scrabble.Matrix
+  ( Matrix(..)
+  , ListMatrix
+  , LM
+  ) where
+
+import Data.Functor.Compose
+
+class Matrix r m | m -> r where
+  elemAt  :: Pos p => (m a) -> p -> Maybe a
+  row     :: m a -> Int -> Maybe (r a)
+  col     :: m a -> Int -> Maybe (r a)
+  rows    :: m a -> m a
+  cols    :: m a -> m a
+  above   :: Pos p => m a -> p -> r a
+  below   :: Pos p => m a -> p -> r a
+  leftOf  :: Pos p => m a -> p -> r a
+  rightOf :: Pos p => m a -> p -> r a
+
+-- | The composition of two lists forms a "matrix".
+type ListMatrix = Compose [] []
+
+-- | A shorthand for getting the list-of-list out of a 'ListMatrix',
+-- and putting one back in.
+pattern LM a = Compose a
+
+instance Matrix [] ListMatrix where
+  elemAt  (LM m) p | x >= 0 && y >= 0 = Just (m !! y !! x) where (x,y) = coors p
+  elemAt  _ _ = Nothing
+  row     (LM m) y | y >= 0 = Just $ m !! y
+  row     _ _ = Nothing
+  col     (LM m) x | x >= 0 = Just $ fmap (!!x) m
+  col     _ _ = Nothing
+  rows    m   = m
+  cols    m   = Maybe.catMaybes $ fmap (col m) [0..14]
+  above   m p = Maybe.fromMaybe [] $ before (y p) <$> col m (x p)
+  below   m p = Maybe.fromMaybe [] $ after  (y p) <$> col m (x p)
+  leftOf  m p = Maybe.fromMaybe [] $ before (x p) <$> row m (y p)
+  rightOf m p = Maybe.fromMaybe [] $ after  (x p) <$> row m (y p)
+

--- a/Haskell/src/Scrabble/Search.hs
+++ b/Haskell/src/Scrabble/Search.hs
@@ -1,7 +1,7 @@
 module Scrabble.Search where
 
 import Data.Char (toUpper)
-import Data.List (delete)
+import Data.List (delete, foldl')
 import System.Random.Shuffle
 import Prelude hiding (Word, or, and, all)
 import Scrabble.Types


### PR DESCRIPTION
A matrix can now be a simple `* -> *` type constructor, and needn't be something that "just works" when you use it like `m (m a)`.

This also changes the basic board type to `Compose [] [] Square` instead of `[[Square]]`.  That's necessary to make the kinds match up.  The `LM` pattern synonym is provided to ease the way.

Ideally the connection between `class Board` and `class Matrix` should be broken too, but this is a good start.
