### PR TITLE
Compare ids

### DIFF
--- a/web/wai-server/Main.hs
+++ b/web/wai-server/Main.hs
@@ -56,7 +56,7 @@ socketsApp ref = websocketsOr defaultConnectionOptions wsApp defaultApp where
     notFound path = Wai.responseLBS  status404 [("Content-Type", "text/plain")] (LB.append "404 - Not Found: " path)
 
   -- | Connect with the incoming websocket request, set up communication with it in general.
-  connect :: Show a => MVar (PlayerName, Connection) -> PendingConnection -> IORef a -> a -> IO ()
+  connect :: MVar (PlayerName, Connection) -> PendingConnection -> IORef Int -> Int -> IO ()
   connect convar pending_conn ref i = do
     conn <- acceptRequest pending_conn
     writeIORef ref i
@@ -66,7 +66,7 @@ socketsApp ref = websocketsOr defaultConnectionOptions wsApp defaultApp where
     sendTextData conn (B.pack $ show i)
     putMVar convar (name, conn)
     forkPingThread conn 30
-    forever $ receiveMove (read $ show i :: Int) conn -- listen for moves, forever.
+    forever $ receiveMove i conn -- listen for moves, forever.
 
   -- | receive a move (and game) from a player, and attempt to apply it
   --   if it isn't the players turn, or the move results in an error,

--- a/web/wai-server/Main.hs
+++ b/web/wai-server/Main.hs
@@ -38,8 +38,8 @@ socketsApp ref = websocketsOr defaultConnectionOptions wsApp defaultApp where
   wsApp pending_conn = do
     i <- readIORef ref
     case i of
-      0 -> connect player1 pending_conn ref 0
-      1 -> connect player2 pending_conn ref 1
+      0 -> connect player1 pending_conn ref 1
+      1 -> connect player2 pending_conn ref 2
       _ -> rejectRequest pending_conn "too many players"
 
   -- | This is a simple app that just serves up some html and javascript


### PR DESCRIPTION
You'll see that in the first commit I tried to change the numbers sent over the wire to "0" and "1", but this caused a strange bug where the server seemed to only send "0". In the end I decided to leave them as is and interpret "0" as "1" and "1" as "2"  on the client side. 

Other than that, the part where I compare ids instead of names should be easy to see. Note that since the input part of the client is non-operational I haven't had a chance to test this, but drag and drop input is next on my todo list so we'll find out soon.  
