### PR TITLE
fix board decoding so that decode (encode g) == g 

### DIFF
--- a/scrabble.cabal
+++ b/scrabble.cabal
@@ -54,6 +54,7 @@ library
     base  >= 4.7 && < 5
    ,aeson >= 0.9.0.1
    ,array
+   ,bifunctors
    ,bytestring
    ,containers
    ,parsers

--- a/src/Scrabble/Board/Board.hs
+++ b/src/Scrabble/Board/Board.hs
@@ -39,7 +39,7 @@ import Scrabble.Board.Square
 
 data Board = Board {
   contents :: (Array Point Square)
-} deriving (Eq, Ord, Generic)
+} deriving (Eq, Ord, Generic, Show)
 
 instance ToJSON Board where
   toJSON (Board b) = toJSON . fmap g . filter f $ A.assocs b where
@@ -48,7 +48,9 @@ instance ToJSON Board where
 
 instance FromJSON Board where
   parseJSON = withArray "Board" $ \arr ->
-    Board . (newBoard //) <$> mapM parseJSON (V.toList arr)
+    Board . (newBoard //) . fmap rebuildSquare <$> mapM parseJSON (V.toList arr)
+    where rebuildSquare (p,t) =
+            (p, Square (Just t) (maybe NoBonus id $ lookup p boardBonuses) p )
 
 type Row = Array Int Square
 type Col = Array Int Square

--- a/src/Scrabble/Board/Board.hs
+++ b/src/Scrabble/Board/Board.hs
@@ -25,18 +25,19 @@ module Scrabble.Board.Board
 
 import Data.Aeson (ToJSON, FromJSON, toJSON, parseJSON, withArray)
 import Data.Array (Array, listArray)
-import qualified Data.Array as A
 import Data.List (intercalate)
-import qualified Data.Maybe as Maybe
 import Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Data.Vector as V
 import GHC.Generics
 import Scrabble.Bag
 import Data.Bifunctor (second)
 import Scrabble.Board.Orientation
 import Scrabble.Board.Point
 import Scrabble.Board.Square
+
+import qualified Data.Array  as A
+import qualified Data.Maybe  as Maybe
+import qualified Data.Set    as Set
+import qualified Data.Vector as V
 
 data Board = Board {
   contents :: (Array Point Square)

--- a/src/Scrabble/Board/Square.hs
+++ b/src/Scrabble/Board/Square.hs
@@ -33,7 +33,7 @@ data Square = Square {
   tile      :: Maybe Tile,
   bonus     :: Bonus,
   squarePos :: Point
-} deriving (Eq, Ord, Generic, ToJSON, FromJSON)
+} deriving (Eq, Ord, Generic)
 
 instance Show Square where
   show = showSquare True


### PR DESCRIPTION
As per your instructions on slack, I removed the auto generated instances from Square and wrote all the decoding logic into the Board instance. This solution works but seems like it might be inefficient; it looks up the bonuses for each position and then goes back over `newBoard` again to rebuild the full board, when this could probably all be done in a single pass. I also added a Show instance to Board in the course of debugging.
