### PR TITLE
Handle both changing the game state for both clients and checking move validity for single clients 

### DIFF
--- a/web/wai-server/ClientMessage.hs
+++ b/web/wai-server/ClientMessage.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
+
+module ClientMessage where
+
+import Data.Aeson
+import Scrabble
+import GHC.Generics
+
+
+data MessageType = ValidityCheck | ActualMove
+    deriving (Show, Eq, Generic, FromJSON)
+
+data ClientMessage = Message MessageType Game WordPut
+    deriving (Eq, Generic, FromJSON)

--- a/web/wai-server/Main.hs
+++ b/web/wai-server/Main.hs
@@ -83,14 +83,12 @@ receiveMessage pid conn = do
     messageData <- receiveData conn
     case decodeAndCheckTurn messageData of
         Right (Message ActualMove g m) ->
-            case applyWordPut g m of 
+            case applyWordPut g m of
                 Right newGame -> updateBothClients newGame
                 Left errMsg -> sendTextData conn (B.pack errMsg)
         Right (Message ValidityCheck g m) ->
             sendTextData conn $ encode $
                 either (const True) (const False) (applyWordPut g m)
-
-
         Left errMsg -> sendTextData conn (B.pack errMsg)
     where
         decodeAndCheckTurn :: B.ByteString -> Either String ClientMessage

--- a/web/wai-server/Main.hs
+++ b/web/wai-server/Main.hs
@@ -73,13 +73,17 @@ socketsApp ref = websocketsOr defaultConnectionOptions wsApp defaultApp where
 --   decode the message and check if it's the player's turn
 --   propagating error message along the way
 --   then match on the MessageType and handle each message appropriately
+--   if the client just wants a ValidityCheck, apply the move but only
+--   return whether it applied sucessfully or not
+--   if the client wants an ActualMove, then apply the move and return
+--   the updated game state or an error
 
 receiveMessage :: Int -> Connection -> IO ()
 receiveMessage pid conn = do
     messageData <- receiveData conn
     case decodeAndCheckTurn messageData of
         Right (Message ActualMove g m) ->
-            case applyWordPut g m of --apply the move, update both clients
+            case applyWordPut g m of 
                 Right newGame -> updateBothClients newGame
                 Left errMsg -> sendTextData conn (B.pack errMsg)
         Right (Message ValidityCheck g m) ->

--- a/web/wai-server/Main.hs
+++ b/web/wai-server/Main.hs
@@ -85,7 +85,7 @@ receiveMessage pid conn = do
         Right (Message ActualMove g m) ->
             case applyWordPut g m of
                 Right newGame -> updateBothClients newGame
-                Left errMsg -> sendTextData conn (B.pack errMsg)
+                Left errMsg   -> sendTextData conn (B.pack errMsg)
         Right (Message ValidityCheck g m) ->
             sendTextData conn $ encode $
                 either (const True) (const False) (applyWordPut g m)


### PR DESCRIPTION
Following the style of recieveGame, the message is decoded and the playerId is checked to verify that it is the player's turn. This means that the player who isnt in their turn wont be able to check future moves, this may or may not make sense from a gameplay perspective. I kept both decoding and turn checking in the same function to leverage the behavior of the Either monad. from there, depending on the MessageType, the message is dispatched to functions that do the necessary computation and send the result to the necessary clients. I have a feeling this can all be written more compactly, let me know what you think.
