### PR TITLE
Small fix for functional client communication

### DIFF
--- a/web/wai-server/ClientMessage.hs
+++ b/web/wai-server/ClientMessage.hs
@@ -8,7 +8,7 @@ import GHC.Generics
 
 
 data MessageType = ValidityCheck | ActualMove
-    deriving (Eq, Generic, FromJSON)
+    deriving (Show, Eq, Generic, FromJSON)
 
 data ClientMessage = Message MessageType Game WordPut
     deriving (Eq, Generic, FromJSON)

--- a/web/wai-server/ClientMessage.hs
+++ b/web/wai-server/ClientMessage.hs
@@ -8,7 +8,7 @@ import GHC.Generics
 
 
 data MessageType = ValidityCheck | ActualMove
-    deriving (Show, Eq, Generic, FromJSON)
+    deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data ClientMessage = Message MessageType Game WordPut
-    deriving (Eq, Generic, FromJSON)
+    deriving (Eq, Generic, ToJSON, FromJSON)

--- a/web/wai-server/ClientMessage.hs
+++ b/web/wai-server/ClientMessage.hs
@@ -8,7 +8,7 @@ import GHC.Generics
 
 
 data MessageType = ValidityCheck | ActualMove
-    deriving (Show, Eq, Generic, ToJSON, FromJSON)
+    deriving (Eq, Generic, FromJSON)
 
 data ClientMessage = Message MessageType Game WordPut
-    deriving (Eq, Generic, ToJSON, FromJSON)
+    deriving (Eq, Generic, FromJSON)

--- a/web/wai-server/Main.hs
+++ b/web/wai-server/Main.hs
@@ -88,13 +88,14 @@ receiveMessage pid conn = do
                 Left errMsg   -> sendTextData conn (B.pack errMsg)
         Right (Message ValidityCheck g m) ->
             sendTextData conn $ encode $
-                either (const True) (const False) (applyWordPut g m)
+                either (const False) (const True) (applyWordPut g m)
         Left errMsg -> sendTextData conn (B.pack errMsg)
     where
         decodeAndCheckTurn :: B.ByteString -> Either String ClientMessage
         decodeAndCheckTurn m = do
             msg@(Message _ g _) <- eitherDecode $ LB.fromStrict m
-            if (playerId . NE.head $ gamePlayers g) == pid
+            -- thread ids (`pid` in this function) are one ahead of the client side player id
+            if (playerId . NE.head $ gamePlayers g) + 1  ==  pid
             then Right msg
             else Left "Not your turn"
 


### PR DESCRIPTION
The first fix is to flip the first two arguments passed to `either`, otherwise the button will be greyed when the move is valid and ungreyed when it's valid. The second fix relates back to the whole id number fiasco from a while ago; long story short I have to add one to the incoming id to be able to compare them. This seems very hacky, we can talk about whether it warrants more thinking about how the ids are set up.
