### PR TITLE
Fix validation of moves with blank tiles

### DIFF
--- a/scrabble.cabal
+++ b/scrabble.cabal
@@ -86,6 +86,7 @@ test-suite tests
     Scrabble.BoardTests
     Scrabble.GameTests
     Scrabble.Move.WordPutTests
+    Scrabble.Move.MoveTests
     Scrabble.ScrabbleTests
     Scrabble.SearchTests
     Scrabble.TileTests

--- a/src/Scrabble/Move/Move.hs
+++ b/src/Scrabble/Move/Move.hs
@@ -64,15 +64,10 @@ rackRemainder (Rack r) (WordPut tps) = Rack $ foldl' f r tps
     where
       rackLetters = map letter r
 
-      -- Get the tile associated with a TilePut so you can delete it in f
-      toTile :: TilePut -> Tile
-      toTile (LetterTilePut t _) = t
-      toTile (BlankTilePut _ _)  = fromLetter Blank
-
       f :: [Tile] -> TilePut -> [Tile]
       f remainingTiles tp =
           if elem (letter tp) rackLetters || elem Blank rackLetters
-          then delete (toTile tp) remainingTiles
+          then delete (asBlankTile tp) remainingTiles
           else remainingTiles
 
 

--- a/src/Scrabble/Move/Move.hs
+++ b/src/Scrabble/Move/Move.hs
@@ -62,15 +62,18 @@ containsAllWithBlanks s1 s2 = fst $ foldl' f (True, ups s2) (ups s1) where
 rackRemainder :: Rack -> WordPut -> Rack
 rackRemainder (Rack r) (WordPut tps) = Rack $ foldl' f r tps
     where
-    f :: [Tile] -> TilePut -> [Tile]
-    f r tp = if elem (letter tp) rackLetters || elem Blank rackLetters
-           then delete offendingTile r
-           else r
-             where
-               rackLetters = map letter r
-               offendingTile = case tp of
-                                 LetterTilePut t _ -> t
-                                 BlankTilePut  _ _ -> mkTile Blank
+      rackLetters = map letter r
+
+      -- Get the tile associated with a TilePut so you can delete it in f
+      toTile :: TilePut -> Tile
+      toTile (LetterTilePut t _) = t
+      toTile (BlankTilePut _ _)  = fromLetter Blank
+
+      f :: [Tile] -> TilePut -> [Tile]
+      f remainingTiles tp =
+          if elem (letter tp) rackLetters || elem Blank rackLetters
+          then delete (toTile tp) remainingTiles
+          else remainingTiles
 
 
 -- | Attempt to lay tiles on the board.

--- a/src/Scrabble/Move/WordPut.hs
+++ b/src/Scrabble/Move/WordPut.hs
@@ -49,6 +49,10 @@ asTile :: TilePut -> Tile
 asTile (LetterTilePut t _) = t
 asTile (BlankTilePut  l _) = fromLetter l
 
+asBlankTile :: TilePut -> Tile
+asBlankTile (LetterTilePut t _) = t
+asBlankTile (BlankTilePut _ _)  = fromLetter Blank
+
 tilePutPoint :: TilePut -> Point
 tilePutPoint (LetterTilePut _ p) = p
 tilePutPoint (BlankTilePut  _ p) = p

--- a/src/Scrabble/Search.hs
+++ b/src/Scrabble/Search.hs
@@ -7,12 +7,10 @@ module Scrabble.Search
   , Scrabble.Search.any
   , cheat
   , containsAll
-  , containsAllWithBlanks
   , containsAny
   , containsNone
   , containsOnly
   , containsLetterAtPos
-  , countBlanksUsed
   , dictionary
   , dictionaryUnsafe
   , endsWith
@@ -26,6 +24,7 @@ module Scrabble.Search
   , searchWordBagForPowersetSorted
   , startsWith
   , testSearch
+  , ups
   , wordBagContainsWord
 ) where
 
@@ -55,22 +54,6 @@ type Search = String -> Bool
 containsAll :: String -> Search
 containsAll s1 s2 = fst $ foldl' f (True, ups s2) (ups s1) where
   f (b,s) c = if elem c s then (b, delete c s) else (False,s)
-
--- | Like the above, but if it encounters a character in in s1 not in
---   s2, it deletes a blank and tries again before returning false
-containsAllWithBlanks :: String -> Search
-containsAllWithBlanks s1 s2 = fst $ foldl' f (True, ups s2) (ups s1) where
-    f (b,s) c = if elem c s then (b, delete c s)
-                else if elem '_' s then (b, delete '_' s)
-                else (False, s)
-
-
-countBlanksUsed :: String -> String -> Int
-countBlanksUsed s1 s2 = fst $ foldl' f (0, ups s2) (ups s1) where
-    f (count,s) c = if elem c s then (count , delete c s)
-                else if elem '_' s then (count + 1, delete '_' s)
-                else (count, s)
-
 
 -- | Finds all words containing any of the given characters.
 containsAny :: String -> Search

--- a/src/Scrabble/Search.hs
+++ b/src/Scrabble/Search.hs
@@ -7,10 +7,12 @@ module Scrabble.Search
   , Scrabble.Search.any
   , cheat
   , containsAll
+  , containsAllWithBlanks
   , containsAny
   , containsNone
   , containsOnly
   , containsLetterAtPos
+  , countBlanksUsed
   , dictionary
   , dictionaryUnsafe
   , endsWith
@@ -53,6 +55,22 @@ type Search = String -> Bool
 containsAll :: String -> Search
 containsAll s1 s2 = fst $ foldl' f (True, ups s2) (ups s1) where
   f (b,s) c = if elem c s then (b, delete c s) else (False,s)
+
+-- | Like the above, but if it encounters a character in in s1 not in
+--   s2, it deletes a blank and tries again before returning false
+containsAllWithBlanks :: String -> Search
+containsAllWithBlanks s1 s2 = fst $ foldl' f (True, ups s2) (ups s1) where
+    f (b,s) c = if elem c s then (b, delete c s)
+                else if elem '_' s then (b, delete '_' s)
+                else (False, s)
+
+
+countBlanksUsed :: String -> String -> Int
+countBlanksUsed s1 s2 = fst $ foldl' f (0, ups s2) (ups s1) where
+    f (count,s) c = if elem c s then (count , delete c s)
+                else if elem '_' s then (count + 1, delete '_' s)
+                else (count, s)
+
 
 -- | Finds all words containing any of the given characters.
 containsAny :: String -> Search

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,6 +18,7 @@ import qualified Scrabble.Move.WordPutTests as WordPutTests
 import qualified Scrabble.ScrabbleTests     as ScrabbleTests
 import qualified Scrabble.SearchTests       as SearchTests
 import qualified Scrabble.TileTests         as TileTests
+import qualified Scrabble.Move.MoveTests    as MoveTests
 
 --For a complete example, see: http://bit.ly/1G5MIoq
 --also: https://hackage.haskell.org/package/test-framework-th
@@ -35,4 +36,5 @@ allTests =
   , ScrabbleTests.tests
   , SearchTests.tests
   , TileTests.tests
-  , WordPutTests.tests ]
+  , WordPutTests.tests
+  , MoveTests.tests]

--- a/test/Scrabble/Move/MoveTests.hs
+++ b/test/Scrabble/Move/MoveTests.hs
@@ -12,11 +12,8 @@ import Scrabble.Bag
 
 
 case_create_move =
-    let rack = Rack    [ fromLetter O, fromLetter P, fromLetter T ]
-        wp   = WordPut [ LetterTilePut (fromLetter T) (7,7)
-                       , LetterTilePut (fromLetter O) (7,8)
-                       , LetterTilePut (fromLetter P) (7,9)
-                       ]
+    let rack       = Rack [fromLetter O, fromLetter P, fromLetter T ]
+        (Right wp) = makeWordPut "TOP" Vertical (7,7) []
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
             return $ Move wp score (Rack []) board'
@@ -25,11 +22,8 @@ case_create_move =
 
 
 case_create_move_single_blank =
-    let rack = Rack    [ fromLetter O, fromLetter P, fromLetter Blank]
-        wp   = WordPut [ BlankTilePut T (7,7)
-                       , LetterTilePut (fromLetter O) (7,8)
-                       , LetterTilePut (fromLetter P) (7,9)
-                       ]
+    let rack       = Rack [ fromLetter O, fromLetter P, fromLetter Blank]
+        (Right wp) = makeWordPut "TOP" Vertical (7,7) []
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
             return $ Move wp score (Rack []) board'
@@ -38,11 +32,8 @@ case_create_move_single_blank =
 
 
 case_create_move_many_blanks =
-    let rack = Rack    [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
-        wp   = WordPut [ BlankTilePut T (7,7)
-                       , LetterTilePut (fromLetter O) (7,8)
-                       , LetterTilePut (fromLetter P) (7,9)
-                       ]
+    let rack       = Rack [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
+        (Right wp) = makeWordPut "_OP" Vertical (7,7) ['T']
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
             return $ Move wp score (Rack [fromLetter Blank]) board'
@@ -51,12 +42,9 @@ case_create_move_many_blanks =
 
 
 case_create_move_all_blanks =
-    let rack = Rack    [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
-        wp   = WordPut [ BlankTilePut T (7,7)
-                       , LetterTilePut (fromLetter O) (7,8)
-                       , LetterTilePut (fromLetter P) (7,9)
-                       , BlankTilePut S (7,10)
-                       ]
+    let rack       = Rack [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
+        (Right wp) = makeWordPut "_OP_" Vertical (7,7) ['T', 'S']
+
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
             return $ Move wp score (Rack []) board'

--- a/test/Scrabble/Move/MoveTests.hs
+++ b/test/Scrabble/Move/MoveTests.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Scrabble.Move.MoveTests where
+
+import Test.Framework.Providers.HUnit
+import Test.Framework.TH
+import Test.HUnit
+import TestHelpers
+import Scrabble.Move.Move
+import Scrabble.Board.Board
+import Scrabble.Bag
+
+
+case_create_move =
+    let rack = Rack    [ Tile O 3, Tile P 5, Tile T 3 ]
+        wp   = WordPut [ LetterTilePut (Tile T 3) (7,7)
+                       , LetterTilePut (Tile O 3) (7,8)
+                       , LetterTilePut (Tile P 5) (7,9)
+                       ]
+        expected = do
+            (board',score) <- wordPut standardValidation newBoard wp dict
+            return $ Move wp score (Rack []) board'
+
+    in createMove newBoard rack wp dict @?= expected
+
+case_create_move_with_blank =
+    let rack = Rack    [ Tile O 3, Tile P 5, Tile Blank 0]
+        wp   = WordPut [ BlankTilePut T (7,7)
+                       , LetterTilePut (Tile O 3) (7,8)
+                       , LetterTilePut (Tile P 5) (7,9)
+                       ]
+        expected = do
+            (board',score) <- wordPut standardValidation newBoard wp dict
+            return $ Move wp score (Rack []) board'
+
+    in createMove newBoard rack wp dict @?= expected
+
+
+-- Orphan, but needed for hunit
+instance Show Move where
+    show (Move wp ps r b) =
+        unwords [ "Move"
+                , show wp
+                , show ps
+                , show r
+                , showBoard True b
+                ]
+
+
+tests = $testGroupGenerator

--- a/test/Scrabble/Move/MoveTests.hs
+++ b/test/Scrabble/Move/MoveTests.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Scrabble.Move.MoveTests where
 

--- a/test/Scrabble/Move/MoveTests.hs
+++ b/test/Scrabble/Move/MoveTests.hs
@@ -28,16 +28,10 @@ rackRemainderTest initialRackLetters wpString blankChoices expectedLetters =
   in createMove newBoard rack wp dict @?= expected
 
 
-case_create_move = rackRemainderTest [O,P,T] "TOP" [] []
-
-
-case_create_move_single_blank = rackRemainderTest [O,P,Blank] "_OP" ['T'] []
-
-
-case_create_move_many_blanks = rackRemainderTest [Blank, O, P, Blank] "_OP" ['T'] [Blank]
-
-
-case_create_move_all_blanks = rackRemainderTest [Blank, O, P, Blank] "_OP_" ['T','S'] []
+case_create_move              = rackRemainderTest [O,P,T]              "TOP"  []        []
+case_create_move_single_blank = rackRemainderTest [O,P,Blank]          "_OP"  ['T']     []
+case_create_move_many_blanks  = rackRemainderTest [Blank, O, P, Blank] "_OP"  ['T']     [Blank]
+case_create_move_all_blanks   = rackRemainderTest [Blank, O, P, Blank] "_OP_" ['T','S'] []
 
 -- | this makes sure that you can choose letters for your blank that also happen
 --   be in the rack, and we still consume the blank tile and not the letter tile

--- a/test/Scrabble/Move/MoveTests.hs
+++ b/test/Scrabble/Move/MoveTests.hs
@@ -12,7 +12,7 @@ import Scrabble.Bag
 
 
 case_create_move =
-    let rack       = Rack [fromLetter O, fromLetter P, fromLetter T ]
+    let rack       = Rack $ map fromLetter [O, P, T]
         (Right wp) = makeWordPut "TOP" Vertical (7,7) []
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
@@ -22,8 +22,8 @@ case_create_move =
 
 
 case_create_move_single_blank =
-    let rack       = Rack [ fromLetter O, fromLetter P, fromLetter Blank]
-        (Right wp) = makeWordPut "TOP" Vertical (7,7) []
+    let rack       = Rack $ map fromLetter [O, P, Blank]
+        (Right wp) = makeWordPut "_OP" Vertical (7,7) ['T']
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
             return $ Move wp score (Rack []) board'
@@ -32,7 +32,7 @@ case_create_move_single_blank =
 
 
 case_create_move_many_blanks =
-    let rack       = Rack [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
+    let rack       = Rack $ map fromLetter [ Blank, O, P, Blank]
         (Right wp) = makeWordPut "_OP" Vertical (7,7) ['T']
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
@@ -42,12 +42,21 @@ case_create_move_many_blanks =
 
 
 case_create_move_all_blanks =
-    let rack       = Rack [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
+    let rack       = Rack $ map fromLetter [Blank, O, P, Blank]
         (Right wp) = makeWordPut "_OP_" Vertical (7,7) ['T', 'S']
-
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
             return $ Move wp score (Rack []) board'
+
+    in createMove newBoard rack wp dict @?= expected
+
+-- this is the case that prompted the algorithm change
+case_uses_blank_not_equivalent_tile =
+    let rack       = Rack $ map fromLetter [Blank, P, O, P, S]
+        (Right wp) = makeWordPut "POP_" Vertical (7,7) ['S']
+        expected = do
+            (board',score) <- wordPut standardValidation newBoard wp dict
+            return $ Move wp score (Rack [fromLetter S]) board'
 
     in createMove newBoard rack wp dict @?= expected
 

--- a/test/Scrabble/Move/MoveTests.hs
+++ b/test/Scrabble/Move/MoveTests.hs
@@ -12,10 +12,10 @@ import Scrabble.Bag
 
 
 case_create_move =
-    let rack = Rack    [ Tile O 3, Tile P 5, Tile T 3 ]
-        wp   = WordPut [ LetterTilePut (Tile T 3) (7,7)
-                       , LetterTilePut (Tile O 3) (7,8)
-                       , LetterTilePut (Tile P 5) (7,9)
+    let rack = Rack    [ fromLetter O, fromLetter P, fromLetter T ]
+        wp   = WordPut [ LetterTilePut (fromLetter T) (7,7)
+                       , LetterTilePut (fromLetter O) (7,8)
+                       , LetterTilePut (fromLetter P) (7,9)
                        ]
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict
@@ -23,11 +23,39 @@ case_create_move =
 
     in createMove newBoard rack wp dict @?= expected
 
-case_create_move_with_blank =
-    let rack = Rack    [ Tile O 3, Tile P 5, Tile Blank 0]
+
+case_create_move_single_blank =
+    let rack = Rack    [ fromLetter O, fromLetter P, fromLetter Blank]
         wp   = WordPut [ BlankTilePut T (7,7)
-                       , LetterTilePut (Tile O 3) (7,8)
-                       , LetterTilePut (Tile P 5) (7,9)
+                       , LetterTilePut (fromLetter O) (7,8)
+                       , LetterTilePut (fromLetter P) (7,9)
+                       ]
+        expected = do
+            (board',score) <- wordPut standardValidation newBoard wp dict
+            return $ Move wp score (Rack []) board'
+
+    in createMove newBoard rack wp dict @?= expected
+
+
+case_create_move_many_blanks =
+    let rack = Rack    [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
+        wp   = WordPut [ BlankTilePut T (7,7)
+                       , LetterTilePut (fromLetter O) (7,8)
+                       , LetterTilePut (fromLetter P) (7,9)
+                       ]
+        expected = do
+            (board',score) <- wordPut standardValidation newBoard wp dict
+            return $ Move wp score (Rack [fromLetter Blank]) board'
+
+    in createMove newBoard rack wp dict @?= expected
+
+
+case_create_move_all_blanks =
+    let rack = Rack    [ fromLetter Blank, fromLetter O, fromLetter P,  fromLetter Blank]
+        wp   = WordPut [ BlankTilePut T (7,7)
+                       , LetterTilePut (fromLetter O) (7,8)
+                       , LetterTilePut (fromLetter P) (7,9)
+                       , BlankTilePut S (7,10)
                        ]
         expected = do
             (board',score) <- wordPut standardValidation newBoard wp dict


### PR DESCRIPTION
In order to properly account for blank tiles, I replaced the `containsAll` funtion from Scrabble.Search with a version that after failing to match the letter in the wordput with one in the rack, checks for a blank tile in the rack, and if present deletes it and continues the search. This also involves a change to how you compute the `rackRemainder`, and I used a similar technique as in `containsAll` to count the number of blank tiles that get used up in order to produce a valid move. I added tests that address 4 cases: No blank tiles, one blank tile, one of two blank tiles being used, and all two blank tiles being used.
